### PR TITLE
use UTC clock and appropriate date format for AWS

### DIFF
--- a/src/main/java/com/hubrick/vertx/s3/client/S3Client.java
+++ b/src/main/java/com/hubrick/vertx/s3/client/S3Client.java
@@ -84,7 +84,7 @@ public class S3Client {
     private final boolean signPayload;
 
     public S3Client(Vertx vertx, S3ClientOptions s3ClientOptions) {
-        this(vertx, s3ClientOptions, Clock.systemDefaultZone());
+        this(vertx, s3ClientOptions, Clock.systemUTC());
     }
 
     public S3Client(Vertx vertx, S3ClientOptions s3ClientOptions, Clock clock) {

--- a/src/main/java/com/hubrick/vertx/s3/signature/AWS4SignatureBuilder.java
+++ b/src/main/java/com/hubrick/vertx/s3/signature/AWS4SignatureBuilder.java
@@ -56,7 +56,7 @@ public class AWS4SignatureBuilder {
 
     private final static Pattern QUERY_STRING_MATCHING_PATTERN = Pattern.compile("([^=]+)=?([^&]*)&?");
     private final static String DEFAULT_ALGORITHM = "AWS4-HMAC-SHA256";
-    private final static DateTimeFormatter SIGNATURE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmssX");
+    private final static DateTimeFormatter SIGNATURE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'");
     private final static DateTimeFormatter CREDENTIAL_SCOPE_DATE = DateTimeFormatter.ofPattern("yyyyMMdd");
     private final static String CREDENTIAL_SCOPE_TERMINATION_STRING = "aws4_request";
     private final static String ESCAPE_SAFE_CHARACTERS = "-_.*~";


### PR DESCRIPTION
As discussed in #5, we suspected inability to `PUT` and related AMZ response of `AWS authentication requires a valid Date or x-amz-date header` was due to a non-UTC clock being used during a daylight savings period (British Summer Time, in my case). This fixes it.