### PR TITLE
Added ServerSideEncryption support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,34 @@ A fully functional Vert.x client for S3
                 response -> System.out.println("Response from AWS: " + response.getData().getName()),
                 Throwable::printStackTrace
         );
+        
+        // putObject with server-side-encryption
+        s3Client.putObjectSse(
+                S3_BUCKET_NAME,
+                KEY_ENCRYPTED,
+                new PutObjectRequest(Buffer.buffer(TEST_FILE_CONTENT))
+                        .withContentType(TEXT_PLAIN),
+                new SseHeadersRequest<>()
+                        .withAmzServerSideEncryptionCustomerAlgorithm(AES_256)
+                        .withAmzServerSideEncryptionCustomerKey(SSE_KEY)
+                        .withAmzServerSideEncryptionCustomerKeyMD5(SSE_KEY_MD5),
+                response -> System.out.println("Response from AWS: " + response.getHeader().getContentType()),
+                Throwable::printStackTrace
+        );
+
+        // getObject with server-side-encryption
+        s3Client.getObjectSse(
+                S3_BUCKET_NAME,
+                KEY_ENCRYPTED,
+                new GetObjectRequest()
+                        .withResponseContentType(TEXT_PLAIN),
+                new SseHeadersRequest<>()
+                        .withAmzServerSideEncryptionCustomerAlgorithm(AES_256)
+                        .withAmzServerSideEncryptionCustomerKey(SSE_KEY)
+                        .withAmzServerSideEncryptionCustomerKeyMD5(SSE_KEY_MD5),
+                response -> System.out.println("Response from AWS: " + response.getHeader().getContentType()),
+                Throwable::printStackTrace
+        );
 ```
 
 ### Multipart upload

--- a/src/main/java/com/hubrick/vertx/s3/client/Headers.java
+++ b/src/main/java/com/hubrick/vertx/s3/client/Headers.java
@@ -64,6 +64,7 @@ public class Headers {
     public static final String X_AMZ_SERVER_SIDE_ENCRYPTION = "x-amz-server-side-encryption";
     public static final String X_AMZ_SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID = "x-amz-server-side-encryption-aws-kms-key-id";
     public static final String X_AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM = "x-amz-server-side-encryption-customer-algorithm";
+    public static final String X_AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY = "X-Amz-Server-Side-Encryption-Customer-Key";
     public static final String X_AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5 = "x-amz-server-side-encryption-customer-key-MD5";
     public static final String X_AMZ_STORAGE_CLASS = "x-amz-storage-class";
     public static final String X_AMZ_TAGGING_COUNT = "x-amz-tagging-count";

--- a/src/main/java/com/hubrick/vertx/s3/model/request/SseHeadersRequest.java
+++ b/src/main/java/com/hubrick/vertx/s3/model/request/SseHeadersRequest.java
@@ -1,0 +1,58 @@
+package com.hubrick.vertx.s3.model.request;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * @author gruboter
+ * @since 3.3.2
+ */
+public class SseHeadersRequest<T extends SseHeadersRequest> {
+
+    private String amzServerSideEncryptionCustomerAlgorithm = "AES256";
+    private String amzServerSideEncryptionCustomerKey;
+    private String amzServerSideEncryptionCustomerKeyMD5;
+
+    public T withAmzServerSideEncryptionCustomerAlgorithm(String amzServerSideEncryptionCustomerAlgorithm) {
+        this.amzServerSideEncryptionCustomerAlgorithm = amzServerSideEncryptionCustomerAlgorithm;
+        return (T) this;
+    }
+
+    public T withAmzServerSideEncryptionCustomerKey(String amzServerSideEncryptionCustomerKey) {
+        this.amzServerSideEncryptionCustomerKey = amzServerSideEncryptionCustomerKey;
+        return (T) this;
+    }
+
+    public T withAmzServerSideEncryptionCustomerKeyMD5(String amzServerSideEncryptionCustomerKeyMD5) {
+        this.amzServerSideEncryptionCustomerKeyMD5 = amzServerSideEncryptionCustomerKeyMD5;
+        return (T) this;
+    }
+
+    public String getAmzServerSideEncryptionCustomerAlgorithm() {
+        return amzServerSideEncryptionCustomerAlgorithm;
+    }
+
+    public String getAmzServerSideEncryptionCustomerKey() {
+        return amzServerSideEncryptionCustomerKey;
+    }
+
+    public String getAmzServerSideEncryptionCustomerKeyMD5() {
+        return amzServerSideEncryptionCustomerKeyMD5;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+}


### PR DESCRIPTION
This PR implements ServerSideEncryption.

## CHANGELOG
1) added ...model.request.SseHeadersRequest
2) added ...client.S3Client.putObjectSse
3) added ...client.S3Client.createPutSseRequest
4) added ...client.S3Client.populateSseHeadersRequest
5) added ...client.Headers.X_AMZ_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY
6) added ...client.S3Client.getObjectSse
7) added ...client.S3Client.createGetSseRequest
8) added server-side-encryption examples to README.md