### PR TITLE
Fix the upload of empty files with the adaptiveUpload API.

### DIFF
--- a/src/main/java/com/hubrick/vertx/s3/util/ChunkedBufferReadStream.java
+++ b/src/main/java/com/hubrick/vertx/s3/util/ChunkedBufferReadStream.java
@@ -80,7 +80,9 @@ public class ChunkedBufferReadStream implements ReadStream<Buffer> {
     private void handleChunk() {
         try {
             boolean pushed = false;
-            if (buffer.length() >= minChunkSize || (endCalled && buffer.length() > 0)) {
+
+            // Check chunks to make sure that the handler is called at least once.
+            if (buffer.length() >= minChunkSize || (endCalled && (buffer.length() > 0 || chunks == 0))) {
                 pushed = true;
                 if (chunkHandler != null) {
                     chunkHandler.handle(buffer.slice());


### PR DESCRIPTION
When writing an empty file with the adaptiveUpload API, neither the handler nor the exceptionHandler are ever called.

This is caused by a combination of the endHandler not being used in adaptiveUpload:
https://github.com/hubrick/vertx-s3-client/blob/master/src/main/java/com/hubrick/vertx/s3/client/S3Client.java#L312
and the ChunkedBufferReadStream not calling its handler if the buffer length is 0:
https://github.com/hubrick/vertx-s3-client/blob/master/src/main/java/com/hubrick/vertx/s3/util/ChunkedBufferReadStream.java#L83